### PR TITLE
Adds field for alternate lookup if AD domain is not the same as email domain

### DIFF
--- a/CentralAuthPlugin.php
+++ b/CentralAuthPlugin.php
@@ -55,6 +55,7 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
         'central_auth_ldap_accountCanonicalForm' => 1,
         'central_auth_ldap_accountDomainName' => 'example.com',
         'central_auth_ldap_accountDomainNameShort' => 'EXAMPLE',
+        'central_auth_ldap_alternateDomainName' => 'email.school.edu',
         'central_auth_ldap_accountFilterFormat' => 'uid=%s'
     );
 
@@ -204,6 +205,13 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
                         $options[$key] = $value;
                     }
                 }
+            }
+
+            /* alternateDomainName is not actually a valid Zend Ldap field,
+            * However, if the value is provided, we need this field in the saved options in the db for user email lookup in LdapAdapter.php
+            */
+            if($options['alternateDomainName']) {
+                unset($options['alternateDomainName']);
             }
 
             // Create new auth adapter with the options, username and password.

--- a/adapters/LdapAdapter.php
+++ b/adapters/LdapAdapter.php
@@ -28,9 +28,15 @@ class CentralAuth_LdapAdapter extends Zend_Auth_Adapter_Ldap
         $result = parent::authenticate();
 
         if ($result->isValid()) {
+            $alt_auth_domain = get_option('central_auth_ldap_alternateDomainName');
+
+            if(!empty($alt_auth_domain)) {
+                $email_suffix = $alt_auth_domain;
+            } else {
+                $email_suffix = $this->_options['ldap']['accountDomainName'];
+            }
             // If the user authenticated, create their email address.
-            $email = $this->getUsername(). '@'.
-                $this->_options['ldap']['accountDomainName'];
+            $email = $this->getUsername(). '@' .  $email_suffix;
 
             // Lookup the user by their email address in the user table.
             $user = get_db()->getTable('User')->findByEmail($email);

--- a/config_form.php
+++ b/config_form.php
@@ -17,8 +17,8 @@ $sections = array(
             'label' => __('Mode'),
             'explanation' => __(
                 'If single sign on is not working, other authentication'.
-                ' methods will still be allowed so you may still log in.'.
-                ' Otherwise, single sign on takes precedence over LDAP.'
+                    ' methods will still be allowed so you may still log in.'.
+                    ' Otherwise, single sign on takes precedence over LDAP.'
             ),
             'select' => array(
                 '' => 'Disabled',
@@ -57,8 +57,8 @@ $sections = array(
             'label' => __('Account Domain Name'),
             'explanation' => __(
                 'The FQDN domain for which the target CAS server is an'.
-                ' authority. Will be added to usernames to create the email'.
-                ' address used to find users.'
+                    ' authority. Will be added to usernames to create the email'.
+                    ' address used to find users.'
             )
         )
     ),
@@ -89,8 +89,8 @@ $sections = array(
             'checkbox' => true,
             'explanation' => __(
                 'Whether or not the LDAP client should use TLS (aka SSLV2)'.
-                ' encrypted transport. This option should be favored over'.
-                ' Use SSL but not all servers support this newer mechanism.'
+                    ' encrypted transport. This option should be favored over'.
+                    ' Use SSL but not all servers support this newer mechanism.'
             )
         ),
         array(
@@ -99,7 +99,7 @@ $sections = array(
             'checkbox' => true,
             'explanation' => __(
                 'Whether or not the LDAP client should use SSL encrypted'.
-                ' transport. This setting takes precedence over Use StartTLS.'
+                    ' transport. This setting takes precedence over Use StartTLS.'
             )
         ),
         array(
@@ -107,9 +107,9 @@ $sections = array(
             'label' => __('Username'),
             'explanation' => __(
                 'The default credentials username. Some servers require that'.
-                ' this be in DN form. This must be given in DN form if the'.
-                ' LDAP server requires a DN to bind and binding should be'.
-                ' possible with simple usernames.'
+                    ' this be in DN form. This must be given in DN form if the'.
+                    ' LDAP server requires a DN to bind and binding should be'.
+                    ' possible with simple usernames.'
             )
         ),
         array(
@@ -118,7 +118,7 @@ $sections = array(
             'password' => true,
             'explanation' => __(
                 'The default credentials password (used only with username'.
-                ' above).'
+                    ' above).'
             )
         ),
         array(
@@ -127,7 +127,7 @@ $sections = array(
             'checkbox' => true,
             'explanation' => __(
                 'Retrieve the DN for the account used to bind if the username'.
-                ' is not already in DN form.'
+                    ' is not already in DN form.'
             )
         ),
         array(
@@ -155,8 +155,8 @@ $sections = array(
             'label' => __('Account Domain Name'),
             'explanation' => __(
                 'The FQDN domain for which the target LDAP server is an'.
-                ' authority. Will be added to usernames to create the email'.
-                ' address used to find users.'
+                    ' authority. Will be added to usernames to create the email'.
+                    ' address used to find users.'
             )
         ),
         array(
@@ -164,9 +164,17 @@ $sections = array(
             'label' => __('Account Short Domain Name'),
             'explanation' => __(
                 'The short domain for which the target LDAP server is an'.
-                ' authority. This is usually used to specify the NetBIOS'.
-                ' domain name for Windows networks but may also be used by'.
-                ' non-Active Directory servers.'
+                    ' authority. This is usually used to specify the NetBIOS'.
+                    ' domain name for Windows networks but may also be used by'.
+                    ' non-Active Directory servers.'
+            )
+        ),
+        array(
+            'name' => 'central_auth_ldap_alternateDomainName',
+            'label' => __('Alternate Domain Name'),
+            'explanation' => __(
+                'The domain of your email provider if it is not the same as your AD domain. This
+                will be used for AD lookups if provided'
             )
         ),
         array(
@@ -174,9 +182,9 @@ $sections = array(
             'label' => __('Account Filter Format'),
             'explanation' => __(
                 'The LDAP search filter used to search for accounts. This'.
-                ' string is a sprintf() style expression that must contain'.
-                ' one %s to accommodate the username. Leave blank for the'.
-                ' default based upon the LDAP Requires DN setting.'
+                    ' string is a sprintf() style expression that must contain'.
+                    ' one %s to accommodate the username. Leave blank for the'.
+                    ' default based upon the LDAP Requires DN setting.'
             )
         )
     )

--- a/controllers/UsersController.php
+++ b/controllers/UsersController.php
@@ -43,9 +43,9 @@ class CentralAuth_UsersController extends UsersController
             'active',
             array(
                 'label' =>
-                    __('Active?'),
+                __('Active?'),
                 'description' =>
-                    __('Inactive users cannot log in to the site.')
+                __('Inactive users cannot log in to the site.')
             )
         );
 
@@ -71,7 +71,7 @@ class CentralAuth_UsersController extends UsersController
             $this->_helper->flashMessenger(
                 __(
                     'There was an invalid entry on the form.'.
-                    ' Please try again.'
+                        ' Please try again.'
                 ),
                 'error'
             );
@@ -97,7 +97,7 @@ class CentralAuth_UsersController extends UsersController
                 $this->_helper->flashMessenger(
                     __(
                         'The user "%s" was added, but the activation email'.
-                        ' could not be sent.',
+                            ' could not be sent.',
                         $user->username
                     )
                 );
@@ -198,7 +198,7 @@ class CentralAuth_UsersController extends UsersController
             if ($adapter) {
                 $adapter->logout(
                     $this->view->serverUrl().
-                    $this->view->url('/')
+                        $this->view->url('/')
                 );
             }
         }


### PR DESCRIPTION
@kloor I've created a field called alternateDomainName that will be used for email address lookups if a value is provided. It may be a tad clunky as it's stripped out of the Zend Ldap options processed by Zend since it's not a valid Zend Ldap option and then looked up via get_option in the authenticate() method in your CentralAuth_LdapAdapter class.

Thanks for a useful plugin,

Dean
