### PR TITLE
generalize path to internal Omeka Users controller

### DIFF
--- a/controllers/UsersController.php
+++ b/controllers/UsersController.php
@@ -7,7 +7,7 @@
  * @license MIT
  */
 
-require_once '../application/controllers/UsersController.php';
+require_once CONTROLLER_DIR.'/UsersController.php';
 
 /**
  * Omeka Central Auth Plugin: Users Controller Class


### PR DESCRIPTION
The path to Omeka's internal UsersController is hardcoded in this plugin's `controllers/UsersController.php`. This path seems to have changed in more recent Omeka releases (I'm on 2.3.1), which causes the plugin to yield errors when users attempt to log in or log out. 

To fix this gotcha, this branch leverages the more abstract path to the controller dir established within `/omeka/bootstrap.php` to generalize the path to the UsersController:

`require_once CONTROLLER_DIR.'/UsersController.php';`

This allows for successful installation and log in / log out on 2.3.1. If this change won't break earlier versions, it seems preferable to hard coding the variable. 

I checked as far back as Omeka 1.1 and found that CONTROLLER_DIR was defined there too (it's specified there in `omeka/paths.php`), so this should generalize to earlier Omeka releases nicely.
