### PR TITLE
Allow LDAP bind password to be stored in file, not database. Also, reduce number of calls to LDAP server for 2FA.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ vendor/
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock
 
-# An ini file that contains the ldap bind password, if it is not stored in the database.
-ldap\.ini
+# An ini file that contains configuration settings for the plugin.
+central_auth\.ini

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ vendor/
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock
+
+# An ini file that contains the ldap bind password, if it is not stored in the database.
+ldap\.ini

--- a/CentralAuthPlugin.php
+++ b/CentralAuthPlugin.php
@@ -214,10 +214,10 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
         $form = $args['login_form'];
 
         // This option specifies if LDAP authentication should be used.
+        $ldap = get_option('central_auth_ldap');
+        
         if (!empty($plugin_ini['ldap']['mode'])) {
             $ldap = $plugin_ini['ldap']['mode'];
-        } else {
-            $ldap = get_option('central_auth_ldap');
         }
 
         if ($ldap) {
@@ -228,12 +228,13 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
             foreach (array_keys($this->_options) as $option) {
                 if (preg_match($preg, $option)) {
                     $key = preg_replace($preg, '', $option);
-
+                    $value = get_option($option);
+                    
                     if (!empty($plugin_ini['ldap'][$key])) {
                         $value = $plugin_ini['ldap'][$key];
-                        $options[$key] = $value;
-                    } elseif (!empty(get_option($option))) {
-                        $value = get_option($option);
+                    }
+                    
+                    if (!empty($value)) {
                         $options[$key] = $value;
                     }
                 }

--- a/CentralAuthPlugin.php
+++ b/CentralAuthPlugin.php
@@ -199,8 +199,8 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
     /**
      * Filter the login auth adapter.
      *
-     * If requested, atttempts to use LDAP to login the user instead of the
-     * default database auth adapter to authenticate the user.
+     * If login mode is set to LDAP, we will return an LDAP adapter instead of
+     * the default database auth adapter to authenticate the user.
      */
     public function filterLoginAdapter($adapter, $args)
     {
@@ -210,7 +210,7 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
         // This option specifies if LDAP authentication should be used.
         $ldap = get_option('central_auth_ldap');
 
-        if ($ldap) {
+        if ($ldap === 'required') {
             // Build an array for the LDAP auth adapter from plugin options.
             $options = array();
             $preg = '/^central_auth_ldap_/';
@@ -247,14 +247,7 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
                 $form->getValue('password')
             );
 
-            // Attempt to authenticate using LDAP.
-            $result = $adapterLdap->authenticate();
-
-            // If the user authenticated or LDAP authentication is required,
-            // return the LDAP auth adapter as the version to use.
-            if ($result->isValid() || $ldap == 'required') {
-                return $adapterLdap;
-            }
+            return $adapterLdap;
         }
 
         // Return the database auth adapter after setting username/password.

--- a/CentralAuthPlugin.php
+++ b/CentralAuthPlugin.php
@@ -52,6 +52,7 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
         'central_auth_ldap_useSsl' => false,
         'central_auth_ldap_username' => '',
         'central_auth_ldap_password' => '',
+        'central_auth_ldap_use_ini' => false,
         'central_auth_ldap_bindRequiresDn' => false,
         'central_auth_ldap_baseDn' => 'ou=people,dc=example,dc=edu',
         'central_auth_ldap_accountCanonicalForm' => 1,

--- a/CentralAuthPlugin.php
+++ b/CentralAuthPlugin.php
@@ -226,6 +226,20 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
                 }
             }
 
+            // Get LDAP bind password from the ini file if configuration
+            // is set up to do this
+            if ($options['use_ini']) {
+                $ldap_ini = parse_ini_file ('ldap.ini', true);
+                if (isset($ldap_ini['ldap']['bind_password'])) {
+                    $options['password'] = $ldap_ini['ldap']['bind_password'];
+                }
+            }
+
+            // Remove $options['use_ini'] because it's not an option that
+            // is recognized by Zend_Ldap, it's only use is to tell us
+            // where to find the 'password' option
+            unset($options['use_ini']);
+
             // Create new auth adapter with the options, username and password.
             $adapterLdap = new CentralAuth_LdapAdapter(
                 array('ldap' => $options),

--- a/CentralAuthPlugin.php
+++ b/CentralAuthPlugin.php
@@ -227,8 +227,8 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
             }
 
             // Get LDAP bind password from the ini file if configuration
-            // is set up to do this
-            if ($options['use_ini']) {
+            // is set up to do this and a bind username has been entered
+            if (isset($options['username']) && $options['use_ini']) {
                 $ldap_ini = parse_ini_file ('ldap.ini', true);
                 if (isset($ldap_ini['ldap']['bind_password'])) {
                     $options['password'] = $ldap_ini['ldap']['bind_password'];
@@ -238,7 +238,9 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
             // Remove $options['use_ini'] because it's not an option that
             // is recognized by Zend_Ldap, it's only use is to tell us
             // where to find the 'password' option
-            unset($options['use_ini']);
+            if (isset($options['use_ini'])) {
+                unset($options['use_ini']);
+            }
 
             // Create new auth adapter with the options, username and password.
             $adapterLdap = new CentralAuth_LdapAdapter(

--- a/CentralAuthPlugin.php
+++ b/CentralAuthPlugin.php
@@ -52,7 +52,6 @@ class CentralAuthPlugin extends Omeka_Plugin_AbstractPlugin
         'central_auth_ldap_useSsl' => false,
         'central_auth_ldap_username' => '',
         'central_auth_ldap_password' => '',
-        'central_auth_ldap_use_ini' => false,
         'central_auth_ldap_bindRequiresDn' => false,
         'central_auth_ldap_baseDn' => 'ou=people,dc=example,dc=edu',
         'central_auth_ldap_accountCanonicalForm' => 1,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ For LDAP, you must configure the host. You can optionally supply a non-default p
 
 You must update the Base DN with the correct value for your directory. Other options will likely need to be set as well. For more information on all of the LDAP options, see the [Zend_Ldap manual](http://framework.zend.com/manual/1.12/en/zend.ldap.api.html). The [Zend LDAP Authentication manual](http://framework.zend.com/manual/1.12/en/zend.auth.adapter.ldap.html) provides more information and examples for Microsoft Active Directory Server and OpenLDAP.
 
+You may configure LDAP options either via the plugin configuration form in the Omeka Dashboard, or in a central_auth.ini file located in the plugin root directory. Options specified via the Omeka Dashboard, including the LDAP password, will be saved in the site database as plain text. Options specified in the central_auth.ini file, although also stored in plain text, will not be stored in the database. If an option is specified in both the database and the central_auth.ini file, the option value in the central_auth.ini file will take precedence. You may specify some options in the database and some in the .ini file.
+
+To specify ldap options in central_auth.ini, add a section `[ldap]`. This section supports all the options found in the config_form.php file for the plugin configuration form, with the prefix `central_auth_ldap_` removed from the option name. The only exception is the option `central_auth_ldap`, which in the .ini file is represented by `mode`. An example central_auth.ini file is shown below.
+```ini
+[ldap]
+mode=""
+host="ldap.example.edu"
+port=""
+useStartTls=false
+useSsl=false
+username=""
+password=""
+bindRequiresDn=false
+baseDn="ou=people,dc=example,dc=edu"
+accountCanonicalForm=1
+accountDomainName="example.edu"
+accountDomainNameShort="EXAMPLE"
+accountFilterFormat="uid=%s"
+``` 
+
 ## Requirements
 Besides Omeka, required packages are installed via Composer. The following libraries are used:
 

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.1.1",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "d2c0a83b7533d6912e8d516756ebd34f893e9169"
+                "reference": "8afa52cd417f4ec417b4bfe86b68106538a87660"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/d2c0a83b7533d6912e8d516756ebd34f893e9169",
-                "reference": "d2c0a83b7533d6912e8d516756ebd34f893e9169",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8afa52cd417f4ec417b4bfe86b68106538a87660",
+                "reference": "8afa52cd417f4ec417b4bfe86b68106538a87660",
                 "shasum": ""
             },
             "require": {
@@ -60,7 +60,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2018-03-29T19:57:20+00:00"
+            "time": "2018-10-18T06:09:13+00:00"
         },
         {
             "name": "mda515t/simple-cas",
@@ -312,7 +312,7 @@
                 }
             ],
             "description": "The place to keep your cache.",
-            "homepage": "https://github.com/tedious/Stash",
+            "homepage": "http://github.com/tedious/Stash",
             "keywords": [
                 "apc",
                 "cache",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.1.3",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "8afa52cd417f4ec417b4bfe86b68106538a87660"
+                "reference": "d2c0a83b7533d6912e8d516756ebd34f893e9169"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8afa52cd417f4ec417b4bfe86b68106538a87660",
-                "reference": "8afa52cd417f4ec417b4bfe86b68106538a87660",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/d2c0a83b7533d6912e8d516756ebd34f893e9169",
+                "reference": "d2c0a83b7533d6912e8d516756ebd34f893e9169",
                 "shasum": ""
             },
             "require": {
@@ -60,7 +60,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2018-10-18T06:09:13+00:00"
+            "time": "2018-03-29T19:57:20+00:00"
         },
         {
             "name": "mda515t/simple-cas",
@@ -312,7 +312,7 @@
                 }
             ],
             "description": "The place to keep your cache.",
-            "homepage": "http://github.com/tedious/Stash",
+            "homepage": "https://github.com/tedious/Stash",
             "keywords": [
                 "apc",
                 "cache",

--- a/config_form.php
+++ b/config_form.php
@@ -140,6 +140,22 @@ $sections = array(
             )
         ),
         array(
+            'name' => 'central_auth_ldap_use_ini',
+            'label' => __('Use LDAP Bind Password Stored in INI File?'),
+            'checkbox' => true,
+            'explanation' => __(
+          'If checked, rather than use the LDAP Bind Password which is stored ' .
+                'in the database, the plugin will use the LDAP Bind Password which ' .
+                'is stored in the file <code>ldap.ini</code> in the plugin root directory.' .
+                'The file should follow the <a href="http://php.net/parse_ini_file">PHP ini ' .
+                'file format</a>, and resemble the following:<br>' .
+                '<code><br>' .
+                    '[ldap]<br>' .
+                    'bind_password="mybindpassword"<br>' .
+                '</code>'
+            )
+        ),
+        array(
             'name' => 'central_auth_ldap_bindRequiresDn',
             'label' => __('Bind Requires DN'),
             'checkbox' => true,

--- a/config_form.php
+++ b/config_form.php
@@ -140,22 +140,6 @@ $sections = array(
             )
         ),
         array(
-            'name' => 'central_auth_ldap_use_ini',
-            'label' => __('Use LDAP Bind Password Stored in INI File?'),
-            'checkbox' => true,
-            'explanation' => __(
-          'If checked, rather than use the LDAP Bind Password which is stored ' .
-                'in the database, the plugin will use the LDAP Bind Password which ' .
-                'is stored in the file <code>ldap.ini</code> in the plugin root directory.' .
-                'The file should follow the <a href="http://php.net/parse_ini_file">PHP ini ' .
-                'file format</a>, and resemble the following:<br>' .
-                '<code><br>' .
-                    '[ldap]<br>' .
-                    'bind_password="mybindpassword"<br>' .
-                '</code>'
-            )
-        ),
-        array(
             'name' => 'central_auth_ldap_bindRequiresDn',
             'label' => __('Bind Requires DN'),
             'checkbox' => true,

--- a/config_form.php
+++ b/config_form.php
@@ -136,7 +136,11 @@ $sections = array(
             'explanation' => __(
                 'The password of the account used to perform account DN'.
                 ' lookups. If not specified, an anonymous bind will be used.'.
-                '<br><b>Note: Stored in the database as plain text.</b>'
+                '<br><b>Note: Stored in the database as plain text.</b><br>' .
+                'Alternatively, you may store the LDAP Password in the ' .
+                'configuration file <code>central_auth.ini</code> located in' .
+                'the plugin root directory. See this plugin\'s ' .
+                '<code>Readme.md</code> file for more details.'
             )
         ),
         array(

--- a/config_form.php
+++ b/config_form.php
@@ -84,6 +84,7 @@ $sections = array(
             'select' => array(
                 '' => 'Disabled',
                 'required' => 'Required, no other auth will be allowed',
+                'optional' => 'Optional, other auth methods may be used'
             ),
             'explanation' => __(
                 'Single sign on will take precedence even if LDAP is required.'

--- a/config_form.php
+++ b/config_form.php
@@ -84,7 +84,6 @@ $sections = array(
             'select' => array(
                 '' => 'Disabled',
                 'required' => 'Required, no other auth will be allowed',
-                'optional' => 'Optional, other auth methods may be used'
             ),
             'explanation' => __(
                 'Single sign on will take precedence even if LDAP is required.'


### PR DESCRIPTION
This pull request has two major changes.

1. Add an option for the plugin to grab the LDAP server bind password from an ldap.ini file in the plugin root directory. This addresses issue #1.
2. Removes a duplicate call to authenticate the user with the LDAP server. I believe this was initially in the code for the LDAP "optional" option, which allows the plugin to first try LDAP, then if LDAP doesn't authenticate, so authenticate using the default Omeka authentication. The problem that this causes is, if the LDAP server is set up with two-factor authenication (2FA), where the user has to approve a push notification on their phone before the authentication goes through, this forces the user to have to approve 4 total push notications, since the Zend LDAP adapter already authenticates the user twice with the LDAP server. I feel that approving two push notifications is the limit of patience for most people...approving four push notifications is really annoying. To my mind, we can avoid this annoyance by simply forcing people to choose LDAP auth is "required" or "disabled" in the plugin settings. If we do that, then we won't need the extra LDAP authentication call in the plugin.

I'm totally open to adjusting this pull request and making adjustments as needed. Thanks for being open to my changes...I hope to deploy this on a production site at Georgetown University!